### PR TITLE
Generic promise

### DIFF
--- a/src/Adapter/Tornado/EventLoop.php
+++ b/src/Adapter/Tornado/EventLoop.php
@@ -237,6 +237,8 @@ class EventLoop implements \M6Web\Tornado\EventLoop
             while (microtime(true) < $endTime) {
                 yield $this->idle();
             }
+
+            return null;
         })());
     }
 

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -8,13 +8,23 @@ interface EventLoop
      * Waits the resolution of a promise, and returns its value.
      * You should use this function once for your global result.
      *
-     * @return mixed
+     * @template T
+     *
+     * @param Promise<T> $promise
+     *
+     * @return T
      */
     public function wait(Promise $promise);
 
     /**
      * Registers a generator in the event loop to execute it asynchronously.
      * The returned promise will be resolved with the value returned by the generator.
+     *
+     * @template T
+     *
+     * @param \Generator<int, Promise, mixed, T> $generator
+     *
+     * @return Promise<T>
      */
     public function async(\Generator $generator): Promise;
 
@@ -28,8 +38,11 @@ interface EventLoop
      * $function applied to each elements of input traversable.
      * You should use this function each time that you use yield in a foreach loop.
      *
-     * @param \Traversable|array $traversable Input elements
-     * @param callable           $function    must return a generator from an input value, and an optional key
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param \Traversable<TKey, TValue>|array<TKey, TValue>                 $traversable Input elements
+     * @param callable(TValue, TKey): \Generator<int, Promise, mixed, mixed> $function
      */
     public function promiseForeach($traversable, callable $function): Promise;
 
@@ -41,7 +54,11 @@ interface EventLoop
     /**
      * Creates a promise already resolved with $value.
      *
-     * @param mixed $value
+     * @template T
+     *
+     * @param T $value
+     *
+     * @return Promise<T>
      */
     public function promiseFulfilled($value): Promise;
 
@@ -52,6 +69,8 @@ interface EventLoop
 
     /**
      * Creates a promise that will be resolved to null in a future tick of the event loop.
+     *
+     * @return Promise<null>
      */
     public function idle(): Promise;
 
@@ -59,6 +78,8 @@ interface EventLoop
      * Creates a promise that will be resolved to null after a fixed time.
      * ⚠️ The actual measured delay can be greater if your event loop is busy!
      * It also can be a little smaller, depending on your event loop (or system clock) accuracy.
+     *
+     * @return Promise<null>
      */
     public function delay(int $milliseconds): Promise;
 
@@ -72,6 +93,8 @@ interface EventLoop
      * ⚠️ Error handling (stream connection closed for example) might differ between implementations.
      *
      * @param resource $stream
+     *
+     * @return Promise<resource>
      */
     public function readable($stream): Promise;
 
@@ -80,6 +103,8 @@ interface EventLoop
      * ⚠️ Error handling (stream connection closed for example) might differ between implementations.
      *
      * @param resource $stream
+     *
+     * @return Promise<resource>
      */
     public function writable($stream): Promise;
 }

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -3,12 +3,15 @@
 namespace M6Web\Tornado;
 
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 interface HttpClient
 {
     /**
      * Sends a http request and returns a promise that will be resolved with a
      * Psr\Http\Message\ResponseInterface
+     *
+     * @return Promise<ResponseInterface>
      */
     public function sendRequest(RequestInterface $request): Promise;
 }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -4,6 +4,9 @@ namespace M6Web\Tornado;
 
 /**
  * To resolve the value of a promise, you have to yield it from a generator registered in the event loop.
+ *
+ * @template-covariant TValue
+ * @psalm-yield TValue
  */
 interface Promise
 {

--- a/tests/Adapter/Guzzle/GuzzleMockWrapper.php
+++ b/tests/Adapter/Guzzle/GuzzleMockWrapper.php
@@ -10,9 +10,6 @@ final class GuzzleMockWrapper implements GuzzleClientWrapper
     /** @var \GuzzleHttp\Client */
     private $guzzleClient;
 
-    /** @var array */
-    private $transactions = [];
-
     /** @var int */
     public $ticks;
 

--- a/tests/EventLoopTest/AsyncTest.php
+++ b/tests/EventLoopTest/AsyncTest.php
@@ -49,6 +49,7 @@ trait AsyncTest
         };
 
         $eventLoop = $this->createEventLoop();
+        /** @phpstan-ignore-next-line phpstan detects the generator yields a non-promise */
         $promise = $eventLoop->async($createGenerator());
 
         $this->expectException(\Error::class);
@@ -245,6 +246,8 @@ trait AsyncTest
         $generatorWaitALittle = function () use ($eventLoop) {
             yield $eventLoop->idle();
             yield $eventLoop->idle();
+
+            return null;
         };
 
         $unwatchedRejectedPromise = $eventLoop->promiseRejected(new \Exception('Rejected Promise'));

--- a/tests/EventLoopTest/PromiseForeachTest.php
+++ b/tests/EventLoopTest/PromiseForeachTest.php
@@ -46,6 +46,7 @@ trait PromiseForeachTest
 
         $this->expectException(\TypeError::class);
         $eventLoop->wait(
+            /* @phpstan-ignore-next-line phpstan detects the callback is invalid */
             $eventLoop->promiseForeach([1], $callback)
         );
     }


### PR DESCRIPTION
Make promise generic.

This allow static analysis tools (phpstan and psalm) to check and infer more types.
For instance:
```php
/**
  * @return Promise<string>
  */
function createPromise(): Promise
    return $eventLoop->async(function() {
       yield $eventLoop->idle();

       return false;
    }());
}
```
phpstan is able to infer that the actual return is a `Promise<bool>` instead of the expected `Promise<string>`.

psalm is also able to get what type is yielded from a promise (`$bool = yield $boolPromise`), phpstan lack support for `@yield` at the moment. 

<details>
<summary>Demo class</summary>

```php
<?php

use M6Web\Tornado\EventLoop;
use M6Web\Tornado\Promise;

/**
 * The purpose of this class is demonstrate static analysis with generic promises
 */
class Sample
{
    /** @var EventLoop */
    private $eventLoop;

    public function __construct(EventLoop $eventLoop)
    {
        $this->eventLoop = $eventLoop;
    }

    public function promiseFulfilledGenericPromise(): void
    {
        $boolPromise = $this->eventLoop->promiseFulfilled(true);
        $stringPromise = $this->eventLoop->promiseFulfilled('foo');

        $this->assertTypePromiseOfString($stringPromise);
        // Error expects M6Web\Tornado\Promise<string>, M6Web\Tornado\Promise<bool> given.
        $this->assertTypePromiseOfString($boolPromise);
    }

    public function waitResolvePromiseType(): void
    {
        $bool = $this->eventLoop->wait($this->eventLoop->promiseFulfilled(true));
        $string = $this->eventLoop->wait($this->eventLoop->promiseFulfilled('foo'));

        $this->assertTypeString($string);
        // Error expects string, bool given.
        $this->assertTypeString($bool);
    }

    public function asyncInferPromiseTypeFromGenerator(): void
    {
        $boolPromise = $this->eventLoop->async((function (): \Generator {
            yield $this->eventLoop->idle();

            return true;
        })());
        $stringPromise = $this->eventLoop->async((function (): \Generator {
            yield $this->eventLoop->idle();

            return 'foo';
        })());

        $this->assertTypePromiseOfString($stringPromise);
        // Error expects M6Web\Tornado\Promise<string>, M6Web\Tornado\Promise<bool> given.
        $this->assertTypePromiseOfString($boolPromise);
    }

    public function asyncGeneratorsMustYieldPromises(): void
    {
        $createGenerator = function (): \Generator {
            yield null;

            return true;
        };

        // Error expects Generator<int, M6Web\Tornado\Promise, mixed, bool>, Generator<int, null, mixed, true> given.
        $this->eventLoop->async($createGenerator());

        // Error expects callable(mixed, (int|string)): Generator<int, M6Web\Tornado\Promise, mixed, mixed>, Closure(): Generator<int, null, mixed, true> given.
        $this->eventLoop->promiseForeach([], $createGenerator);
    }

    public function promiseForeachKeyValueAndCallbackParameterMustBeCoherent(): void
    {
        $boolList = [true, true, false];

        // Error expects callable(bool, int): Generator<int, M6Web\Tornado\Promise, mixed, mixed>, Closure(string, string): Generator<int, M6Web\Tornado\Promise<void|null>, mixed, null> given.
        $this->eventLoop->promiseForeach($boolList, function (string $value, string $key): \Generator {
            yield $this->eventLoop->idle();

            return null;
        });
    }

    public function inferTypeOfYieldedPromise(): void
    {
        $this->eventLoop->async((function (): \Generator {
            $bool = yield $this->eventLoop->promiseFulfilled(true);
            $string = yield $this->eventLoop->promiseFulfilled('foo');

            $this->assertTypeString($string);
            // Only psalm detect this error, because phpstan do not support @yield: expects string, true provided
            $this->assertTypeString($bool);
        })());
    }

    /**
     * @param Promise<string> $promise
     */
    private function assertTypePromiseOfString(Promise $promise): void
    {
    }

    private function assertTypeString(string $string): void
    {
    }
}
```

</details>